### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/game/hud.rs
+++ b/src/game/hud.rs
@@ -94,13 +94,13 @@ fn listen_game_mode_event(
     for event in game_mode_event_reader.read() {
         match event {
             GameModeEvent::ScoreChanged(new_score) => {
-                labels.p0().single_mut().sections[0].value = format!("Score: {new_score:02.}")
+                labels.p0().single_mut().sections[0].value = format!("Score: {new_score:02}")
             }
             GameModeEvent::HighestScoreChanged(new_highest_score) => {
-                labels.p1().single_mut().sections[0].value = format!("Highest: {new_highest_score:02.}")
+                labels.p1().single_mut().sections[0].value = format!("Highest: {new_highest_score:02}")
             }
             GameModeEvent::WaveChanged(new_wave) => {
-                labels.p2().single_mut().sections[0].value = format!("Wave: {new_wave:02.}")
+                labels.p2().single_mut().sections[0].value = format!("Wave: {new_wave:02}")
             }
         }
     }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.